### PR TITLE
bump 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloud-util"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["ypf <yuitta@163.com>", "Rivtower Technologies <contact@rivtower.com>"]
 edition = "2021"
 license = "Apache-2.0"


### PR DESCRIPTION
因为升级prost和tonic，与0.5.0版本不兼容，因此升级为0.6.0